### PR TITLE
Enable Full Screen Boot Animation for Hlte Devices

### DIFF
--- a/hlte.mk
+++ b/hlte.mk
@@ -31,6 +31,7 @@ PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 # Boot animation
 TARGET_SCREEN_HEIGHT := 1920
 TARGET_SCREEN_WIDTH := 1080
+TARGET_SCREEN_ASPECT_RATIO := 16-by-9
 
 $(call inherit-product, frameworks/native/build/phone-xxhdpi-2048-dalvik-heap.mk)
 


### PR DESCRIPTION
added - TARGET_SCREEN_ASPECT_RATIO := 16-by-9 flag to enable full screen temase boot animation to be used
